### PR TITLE
feat: Add schema support to list_tables and describe_table tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# windsurf rules
+.windsurfrules

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A powerful Model Context Protocol server providing **full read-write access** to
 - [Tools](#tools)
   - [execute_query](#execute_query)
   - [execute_dml_ddl_dcl_tcl](#execute_dml_ddl_dcl_tcl)
+  - [execute_maintenance](#execute_maintenance)
   - [execute_commit](#execute_commit)
   - [execute_rollback](#execute_rollback)
   - [list_tables](#list_tables)
@@ -74,6 +75,12 @@ A powerful Model Context Protocol server providing **full read-write access** to
   - Automatically wrapped in a transaction with configurable timeout
   - Returns a transaction ID for explicit commit
   - **Important safety feature**: The conversation will end after execution, allowing the user to review the results before deciding to commit or rollback
+
+- **execute_maintenance**
+
+  - Execute maintenance commands like VACUUM, ANALYZE, or CREATE DATABASE outside of transactions
+  - Input: `sql` (string): The SQL statement to execute - must be VACUUM, ANALYZE, or CREATE DATABASE
+  - Returns a result object with execution time metrics
 
 - **execute_commit**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-postgres-full-access",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-postgres-full-access",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,10 +263,11 @@ server.tool(
 // Remove prompts since we don't need them, just keeping the direct confirm/rollback model
 server.tool(
   "list_tables",
-  "Get a list of all tables in the database",
-  async (extra) => {
+  "Get a list of all tables in the database's schema, default is 'public'",
+  { schema_name: z.string().describe("Name of the schema") },
+  async (args, extra) => {
     try {
-      const result = await handleListTables(pool);
+      const result = await handleListTables(pool, args.schema_name);
       return transformHandlerResponse(result);
     } catch (error) {
       return {
@@ -284,11 +285,12 @@ server.tool(
 
 server.tool(
   "describe_table",
-  "Get detailed information about a specific table",
-  { table_name: z.string().describe("Name of the table to describe") },
+  "Get detailed information about a specific table, including columns, primary keys, foreign keys, and indexes",
+  { table_name: z.string().describe("Name of the table to describe"),
+    schema_name: z.string().describe("Name of the schema").default("public") },
   async (args, extra) => {
     try {
-      const result = await handleDescribeTable(pool, args.table_name);
+      const result = await handleDescribeTable(pool, args.table_name, args.schema_name);
       return transformHandlerResponse(result);
     } catch (error) {
       return {

--- a/src/lib/tool-handlers.ts
+++ b/src/lib/tool-handlers.ts
@@ -314,7 +314,7 @@ export async function handleExecuteCommit(
   }
 }
 
-export async function handleListTables(pool: pg.Pool) {
+export async function handleListTables(pool: pg.Pool, schemaName: string = "public") {
   const client = await pool.connect();
   try {
     const result = await client.query(`
@@ -327,7 +327,7 @@ export async function handleListTables(pool: pg.Pool) {
       JOIN 
         pg_catalog.pg_class pgc ON t.table_name = pgc.relname
       WHERE 
-        t.table_schema = 'public'
+        t.table_schema = '${schemaName}'
         AND t.table_type = 'BASE TABLE'
       ORDER BY 
         t.table_name
@@ -345,7 +345,7 @@ export async function handleListTables(pool: pg.Pool) {
   }
 }
 
-export async function handleDescribeTable(pool: pg.Pool, tableName: string) {
+export async function handleDescribeTable(pool: pg.Pool, tableName: string, schemaName: string = "public") {
   if (!tableName) {
     return {
       content: [{ type: "text", text: "Error: No table name provided" }],
@@ -369,10 +369,11 @@ export async function handleDescribeTable(pool: pg.Pool, tableName: string) {
       JOIN 
         pg_class ON pg_class.relname = columns.table_name
       WHERE 
-        columns.table_name = $1
+        columns.table_name = '${tableName}'
+        AND columns.table_schema = '${schemaName}'
       ORDER BY 
         ordinal_position
-    `, [tableName]);
+    `);
     
     // Get primary key information
     const pkResult = await client.query(`
@@ -382,9 +383,9 @@ export async function handleDescribeTable(pool: pg.Pool, tableName: string) {
         pg_index i
         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
       WHERE 
-        i.indrelid = $1::regclass
+        i.indrelid = '${schemaName}.${tableName}'::regclass
         AND i.indisprimary
-    `, [`public.${tableName}`]);
+    `);
     
     // Get foreign key information
     const fkResult = await client.query(`
@@ -400,22 +401,22 @@ export async function handleDescribeTable(pool: pg.Pool, tableName: string) {
         JOIN information_schema.constraint_column_usage AS ccu
           ON ccu.constraint_name = tc.constraint_name
           AND ccu.table_schema = tc.table_schema
-      WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = $1
-    `, [tableName]);
+      WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = '${tableName}' AND tc.table_schema = '${schemaName}'
+    `);
     
     // Get table description
     const tableDescResult = await client.query(`
       SELECT pg_catalog.obj_description(pgc.oid, 'pg_class') as table_description
       FROM pg_catalog.pg_class pgc
-      WHERE pgc.relname = $1
-    `, [tableName]);
+      WHERE pgc.relname = '${tableName}' AND pgc.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '${schemaName}')
+    `);
     
     // Get approximate row count
     const rowCountResult = await client.query(`
       SELECT reltuples::bigint AS approximate_row_count
       FROM pg_class
-      WHERE relname = $1
-    `, [tableName]);
+      WHERE relname = '${tableName}' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '${schemaName}')
+    `);
     
     // Get indexes
     const indexesResult = await client.query(`
@@ -437,19 +438,20 @@ export async function handleDescribeTable(pool: pg.Pool, tableName: string) {
         AND a.attnum = ANY(ix.indkey)
         AND i.relam = am.oid
         AND t.relkind = 'r'
-        AND t.relname = $1
+        AND t.relname = '${tableName}' AND t.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '${schemaName}')
       GROUP BY
         i.relname,
         am.amname,
         ix.indisunique
       ORDER BY
         i.relname
-    `, [tableName]);
+    `);
     
     return {
       content: [{ 
         type: "text", 
         text: JSON.stringify({
+          schema_name: schemaName,
           table_name: tableName,
           description: tableDescResult.rows[0]?.table_description || null,
           approximate_row_count: rowCountResult.rows[0]?.approximate_row_count || 0,


### PR DESCRIPTION
This PR enhances the PostgreSQL MCP server to properly support schema-qualified table operations. Key changes include:

- Modified `handleDescribeTable` and `handleListTables` to accept a `schemaName` parameter (defaults to "public")
- Updated all SQL queries to properly qualify tables with schema names
- Improved tool definitions in `index.ts` to:
  - Combine parameters into single schema objects
  - Add better descriptions
  - Set default schema to "public"

Impact:

- Enables working with tables in non-public schemas
- Maintains backward compatibility with public schema tables
- Provides better documentation for API consumers

NOTE: Although it seems that previously it was possible to support listing tables or describing tables from other schemas, in reality, this was only accomplished after multiple errors, and ultimately the LLM used the execute_query tool to complete the task. Adding support for schemaName in list_tables and describe_table would allow the LLM to return results more quickly and accurately.